### PR TITLE
Fix some Windows bugs

### DIFF
--- a/ASCII-Simple-Video-Synth.py
+++ b/ASCII-Simple-Video-Synth.py
@@ -19,8 +19,6 @@ import sys
 from random import randint
 import cProfile
 import code
-import signal
-signal.signal(signal.SIGUSR2, lambda sig, frame: code.interact())
 
 import argparse
 
@@ -118,7 +116,12 @@ def get_compliment_of_average():
         bg = Screen.COLOUR_BLACK
     else: 
         bg = Screen.COLOUR_WHITE
-    fg = AASHF.col255_from_RGB(tr,tg,tb)
+    fg = 0
+    if sys.platform == "win32":
+      fg = AASHF.col15_from_RGB(tr, tg, tb)
+      fg = fg >> 1
+    else:
+      fg = AASHF.col255_from_RGB(tr, tg, tb)
     return (fg , bg)
 
 def draw_strobe(screen):


### PR DESCRIPTION
Firstly, SIGUSR2 is not available on Windows. As neither this or the signal
library were being used currently, they have been removed.
Also, the code used to determine foreground colour in
get_compliment_of_average() needed to take Windows console colours into account.

Note: This has not been thoroughly tested. I have made all the errors disappear, and the program runs, but I'm not 100% sure what I should be seeing regarding the start-up defaults.
There are two other things in this change that I am unsure of:
- whether disregarding the intensity bit in the foreground colour is a problem (wasn't sure if it still needed to be used)
- whether colour depth on other console emulators on Windows such as Windows Terminal need different handling from cmd.exe - as at the moment, *all* consoles on Windows are reduced to 4 bit colour.

See below for a screencap of the resulting program operation based on the default start-up settings on cmd.exe.

![windows](https://user-images.githubusercontent.com/10395940/82982646-32828180-a021-11ea-9e45-c45b89cbf70d.gif)

Here is the same but with Windows Terminal running Powershell:
![windows terminal](https://user-images.githubusercontent.com/10395940/82983726-34e5db00-a023-11ea-9329-caf3040f606c.gif)